### PR TITLE
Resolves minLength-valid and JPathParseException

### DIFF
--- a/Sailpoint/Sailpoint_workflow.xml
+++ b/Sailpoint/Sailpoint_workflow.xml
@@ -2,10 +2,9 @@
 <Workflow name="Sailpoint" version="1.0" xmlns="http://qradar.ibm.com/UniversalCloudRESTAPI/Workflow/V1">
 
     <Parameters>
-        <Parameter name="host" label="xxx-api.identitynow.com" required="true" />
-        <Parameter name="client_id" label="" required="true" />
-        <Parameter name="client_secret" label="" required="true" secret="true" />
-        
+        <Parameter name="host" label="Host" required="true" />
+        <Parameter name="client_id" label="Client ID" required="true" />
+        <Parameter name="client_secret" label="Client Secret" required="true" secret="true" />
     </Parameters>
 
     <Actions>
@@ -23,7 +22,7 @@
             </Header>
             <Payload>
                 <Value name="iss" value="" />
-                <Value name="aud" value="https://${host}/oauth2/token" />
+                <Value name="aud" value="https://${/host}/oauth2/token" />
                 <Value name="jti" value="${time()}${time()}" />
                 <Value name="exp" value="${time() / 1000 + 30}" />
             </Payload>
@@ -33,7 +32,7 @@
         <CallEndpoint url="https://${/host}/oauth2/token" method="POST" savePath="/get_access_token" >
 			
             <UrlEncodedFormRequestBody>
-				<Parameter name="grant_type" value="urn:ietf:params:oauth:grant-type:jwt-bearer" />
+		<Parameter name="grant_type" value="urn:ietf:params:oauth:grant-type:jwt-bearer" />
                 <Parameter name="client_id" value="" />
                 <Parameter name="client_secret" value="" />
                 <Parameter name="assertion" value="${/jwt_assertion}" />


### PR DESCRIPTION
1. Updated Parameters to include valid Labels which removes the cvc-minLength-valid: Value '' with length = '0' is not facet-valid with respect to minLength '1' for type 'nonEmptyString' error

2. Updated Payload section to resolve the JPathParseException: The value 'host' is not a valid JPath expression error